### PR TITLE
Add old vanish back

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,7 +111,7 @@ To ban a player use: ```/execute <playername> ~~~ function ban```
 
 To freeze a player use: ```/execute <playername> ~~~ function tools/freeze```
 
-To enter vanish use: ```/function tools/vanish```,
+To enter vanish use: ```/function tools/vanish```
 
 To be able to fly in survival mode use: ```/function tools/fly```
 

--- a/README.md
+++ b/README.md
@@ -44,9 +44,9 @@ To receive anti-cheat alerts use: ```/function notify```
 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;(C) => Kills all command block minecarts.<br />
 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;(D) => Kills all NPC's. (to enable use /function settings/npc)<br />
 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;(E) => Instant despawn time for command block minecarts.<br />
-&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;(F) => Prevents the placement of beehives, beenests and movingblocks.(Requires GameTest Framework)<br />
-&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;(G) => Additional killing check.(Requires GameTest Framework)<br />
-&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;(H) => Additional item clearing check.(Requires GameTest Framework)<br />
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;(F) => Prevents the placement of beehives, beenests and movingblocks. (Requires GameTest Framework)<br />
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;(G) => Additional killing check. (Requires GameTest Framework)<br />
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;(H) => Additional item clearing check. (Requires GameTest Framework)<br />
 
   Crasher -><br />
 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;(A) => Checks if a player's position is invalid. (Requires GameTest FrameWork)<br />
@@ -77,7 +77,7 @@ To receive anti-cheat alerts use: ```/function notify```
   Killaura -><br />
 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;(A) => Checks for attacking while using an item.<br />
 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;(B) => Checks for no swing. (Instantly detects toolbox killaura)<br />
-&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;(C) => Checks for multi-aura. (Requires Gametest Framewokr)<br />
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;(C) => Checks for multi-aura. (Requires Gametest Framework)<br />
 
   LiquidInteract -><br />
 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;(A) => Checks for breaking liquid source blocks. (Requires GameTest FrameWork)<br />
@@ -111,7 +111,7 @@ To ban a player use: ```/execute <playername> ~~~ function ban```
 
 To freeze a player use: ```/execute <playername> ~~~ function tools/freeze```
 
-To enter vanish use: ```/function tools/vanish```
+To enter vanish use: ```/function tools/vanish```,
 
 To be able to fly in survival mode use: ```/function tools/fly```
 

--- a/animation_controllers/detect_actions.json
+++ b/animation_controllers/detect_actions.json
@@ -256,7 +256,8 @@
 						"sleeping": "query.is_sleeping"
 					}],
 					"on_entry": [
-						"/tag @s remove sleeping"
+						"/tag @s remove sleeping",
+						"/tellraw @a[tag=packetlogger] {\"rawtext\":[{\"text\":\"§߈§r§6[§aScythe§6]§r §bRecieved §aSLEEP§r packet from: §g\"},{\"selector\":\"@s\"},{\"text\":\" §7(type=stop)\"}]}"
 					]
 				},
 				"sleeping": {
@@ -264,7 +265,8 @@
 						"default": "!query.is_sleeping"
 					}],
 					"on_entry": [
-						"/tag @s add sleeping"
+						"/tag @s add sleeping",
+						"/tellraw @a[tag=packetlogger] {\"rawtext\":[{\"text\":\"§߈§r§6[§aScythe§6]§r §bRecieved §aSLEEP§r packet from: §g\"},{\"selector\":\"@s\"},{\"text\":\" §7(type=start)\"}]}"
 					]
 				}
 			}

--- a/animation_controllers/detect_actions.json
+++ b/animation_controllers/detect_actions.json
@@ -161,7 +161,8 @@
 			"states": {
 				"default": {
 					"transitions": [{
-						"right": "query.is_using_item"
+            // wacky solution at fixing a false positive, but whatever
+						"right": "query.is_using_item && query.get_equipped_item_name != 'fishing_rod'"
 					}],
 					"on_entry": [
 						"/tag @s remove right",
@@ -176,8 +177,7 @@
 					"on_entry": [
 						"/tag @s add right",
 						"/tellraw @a[tag=packetlogger] {\"rawtext\":[{\"text\":\"§߈§r§6[§aScythe§6]§r §bRecieved §aRIGHT§r packet from: §g\"},{\"selector\":\"@s\"},{\"text\":\" §7(type=start,ticks=0)\"}]}",
-						"/scoreboard players add @s[tag=hasGUIopen] invmovevl 1",
-						"/execute @s[tag=hasGUIopen] ~~~ tellraw @a[tag=notify] {\"rawtext\":[{\"text\":\"§r§6[§aScythe§6]§r \"},{\"selector\":\"@s\"},{\"text\":\" §1has failed §7(Movement) §4InventoryMods/C §7(is_using)§4. VL= \"},{\"score\":{\"name\":\"@s\",\"objective\":\"invmovevl\"}}]}"
+						"/execute @s[tag=hasGUIopen] ~~~ function checks/alerts/invmove"
 					]
 				}
 			}
@@ -267,6 +267,27 @@
 					"on_entry": [
 						"/tag @s add sleeping",
 						"/tellraw @a[tag=packetlogger] {\"rawtext\":[{\"text\":\"§߈§r§6[§aScythe§6]§r §bRecieved §aSLEEP§r packet from: §g\"},{\"selector\":\"@s\"},{\"text\":\" §7(type=start)\"}]}"
+					]
+				}
+			}
+		},
+		"controller.animation.trident": {
+			"states": {
+				"default": {
+					"transitions": [{
+						"trident": "query.get_equipped_item_name == 'trident'"
+					}],
+					"on_entry": [
+						"/tag @s remove trident",
+						"/scoreboard players set @s last_attack 0"
+					]
+				},
+				"trident": {
+					"transitions": [{
+						"default": "query.get_equipped_item_name != 'trident'"
+					}],
+					"on_entry": [
+						"/tag @s add trident"
 					]
 				}
 			}

--- a/entities/player.json
+++ b/entities/player.json
@@ -115,12 +115,37 @@
 					"value": 2
 				}
 			},
+			"unvanished": {
+				"minecraft:scale": {
+					"value": 1
+				},
+				"minecraft:breathable": {
+					"breathes_solids": false,
+					"total_supply": 15,
+					"suffocate_time": -1,
+					"inhale_time": 3.75,
+					"generates_bubbles": false
+				}
+			},
+			"vanished": {
+				"minecraft:scale": {
+					"value": 0
+				},
+				"minecraft:breathable": {
+					"breathes_solids": true,
+					"total_supply": 15,
+					"suffocate_time": -1,
+					"inhale_time": 3.75,
+					"generates_bubbles": false
+				}
+			},
 			"scythe:kick": {
 				"minecraft:instant_despawn": {
 					"remove_child_entities": true
 				}
 			}
 		},
+		
 		"components": {
 			"minecraft:experience_reward": {
 				"on_death": "Math.Min(query.player_level * 7, 100)"
@@ -206,6 +231,12 @@
 										"operator": "==",
 										"subject": "self",
 										"value": "mayfly"
+									},
+									{
+										"test": "has_tag",
+										"operator": "==",
+										"subject": "self",
+										"value": "vanish"
 									}
 								]
 							}

--- a/entities/player.json
+++ b/entities/player.json
@@ -236,7 +236,7 @@
 										"test": "has_tag",
 										"operator": "==",
 										"subject": "self",
-										"value": "vanish"
+										"value": "oldvanish"
 									}
 								]
 							}

--- a/entities/player.json
+++ b/entities/player.json
@@ -220,7 +220,7 @@
 						"cause": "all",
 						"on_damage": {
 							"filters": {
-								"all_of": [{
+								"any_of": [{
 										"test": "has_tag",
 										"operator": "==",
 										"subject": "self",

--- a/entities/player.json
+++ b/entities/player.json
@@ -666,6 +666,30 @@
 					]
 				}
 			},
+			"unvanish": {
+				"add": {
+					"component_groups": [
+						"unvanished"
+					]
+				},
+				"remove": {
+					"component_groups": [
+						"vanished"
+					]
+				}
+			},
+			"vanish": {
+				"add": {
+					"component_groups": [
+						"vanished"
+					]
+				},
+				"remove": {
+					"component_groups": [
+						"unvanished"
+					]
+				}
+			},
 			"minecraft:entity_spawn": {
 				"add": {
 					"component_groups": [

--- a/functions/checks/assets/vanish.mcfunction
+++ b/functions/checks/assets/vanish.mcfunction
@@ -1,3 +1,3 @@
-effect @s[tag=oldvanish] invisibility 9999 255 true
-effect @s[tag=oldvanish] night_vision 9999 255 true
+effect @s[tag=oldvanish] invisibility 60 255 true
+effect @s[tag=oldvanish] night_vision 60 255 true
 title @s[tag=oldvanish] actionbar §aYOU ARE VANISHED!

--- a/functions/checks/assets/vanish.mcfunction
+++ b/functions/checks/assets/vanish.mcfunction
@@ -1,3 +1,3 @@
-effect @s[tag=oldvanish] invisibility 60 255 true
-effect @s[tag=oldvanish] night_vision 60 255 true
+effect @s[tag=oldvanish] invisibility 9999 255 true
+effect @s[tag=oldvanish] night_vision 9999 255 true
 title @s[tag=oldvanish] actionbar §aYOU ARE VANISHED!

--- a/functions/checks/assets/vanish.mcfunction
+++ b/functions/checks/assets/vanish.mcfunction
@@ -1,0 +1,2 @@
+effect @s[tag=oldvanish] invisibility 9999 255 true
+effect @s[tag=oldvanish] night_vision 9999 255 true

--- a/functions/checks/assets/vanish.mcfunction
+++ b/functions/checks/assets/vanish.mcfunction
@@ -1,2 +1,3 @@
 effect @s[tag=oldvanish] invisibility 9999 255 true
 effect @s[tag=oldvanish] night_vision 9999 255 true
+title @s[tag=oldvanish] actionbar §aYOU ARE VANISHED!

--- a/functions/checks/others.mcfunction
+++ b/functions/checks/others.mcfunction
@@ -3,6 +3,8 @@ scoreboard players add @s[tag=right] right 1
 scoreboard players add @s[scores={last_attack=1..}] last_attack 1
 execute @s[tag=!left,scores={last_attack=10..}] ~~~ function checks/alerts/noswing
 
+execute @s[tag=oldvanish] ~~~ function checks/assets/vanish
+
 tp @s[tag=freeze,tag=moving] ~~~
 
 # If the player is under y=-104 this teleports them back to y=-104

--- a/functions/help.mcfunction
+++ b/functions/help.mcfunction
@@ -66,6 +66,7 @@ tellraw @s[scores={gametestapi=1..}] {"rawtext":[{"text":"§3!freeze <username>�
 tellraw @s[scores={gametestapi=1..}] {"rawtext":[{"text":"§3!stats <username>§r - View a specific players anticheat logs."}]}
 tellraw @s[scores={gametestapi=1..}] {"rawtext":[{"text":"§3!fullreport§r - View everyones anticheat logs."}]}
 tellraw @s[scores={gametestapi=1..}] {"rawtext":[{"text":"§3!vanish§r - Enables/disables vanish (Used for spying on suspects)."}]}
+tellraw @s[scores={gametestapi=1..}] {"rawtext":[{"text":"§3!oldvanish§r - Enables/disables old vanish (Used for spying on suspects)."}]}
 tellraw @s[scores={gametestapi=1..}] {"rawtext":[{"text":"§3!tag <nametag>§r - Adds tag to username in chat window."}]}
 tellraw @s[scores={gametestapi=1..}] {"rawtext":[{"text":"§3!report <player> [reason]§r - Report a player."}]}
 tellraw @s[scores={gametestapi=1..}] {"rawtext":[{"text":"§3!gui - Opens the Scythe Management UI."}]}
@@ -77,5 +78,6 @@ tellraw @s[scores={gametestapi=..0}] {"rawtext":[{"text":"§3/execute <username>
 tellraw @s[scores={gametestapi=..0}] {"rawtext":[{"text":"§3/execute <username> ~~~ tools/stats§r - View a specific players anticheat logs."}]}
 tellraw @s[scores={gametestapi=..0}] {"rawtext":[{"text":"§3/execute @a ~~~ function tools/stats§r - View everyones anticheat logs."}]}
 tellraw @s[scores={gametestapi=..0}] {"rawtext":[{"text":"§3/execute <username> ~~~ tools/vanish§r - Enables/disables vanish (Used for spying on suspects)."}]}
+tellraw @s[scores={gametestapi=..0}] {"rawtext":[{"text":"§3/execute <username> ~~~ tools/oldvanish§r - Enables/disables old vanish (Used for spying on suspects)."}]}
 
 tellraw @s {"rawtext":[{"text":"\n"}]}

--- a/functions/help.mcfunction
+++ b/functions/help.mcfunction
@@ -68,6 +68,7 @@ tellraw @s[scores={gametestapi=1..}] {"rawtext":[{"text":"§3!fullreport§r - Vi
 tellraw @s[scores={gametestapi=1..}] {"rawtext":[{"text":"§3!vanish§r - Enables/disables vanish (Used for spying on suspects)."}]}
 tellraw @s[scores={gametestapi=1..}] {"rawtext":[{"text":"§3!tag <nametag>§r - Adds tag to username in chat window."}]}
 tellraw @s[scores={gametestapi=1..}] {"rawtext":[{"text":"§3!report <player> [reason]§r - Report a player."}]}
+tellraw @s[scores={gametestapi=1..}] {"rawtext":[{"text":"§3!gui - Opens the Scythe Management UI."}]}
 
 # Gametest disabled
 tellraw @s[scores={gametestapi=..0}] {"rawtext":[{"text":"§3/execute <username> ~~~ function tools/ecwipe§r - Clears a players ender chest."}]}

--- a/functions/tools/oldvanish.mcfunction
+++ b/functions/tools/oldvanish.mcfunction
@@ -1,0 +1,13 @@
+tag @s[tag=oldvanish] add oldnovanish
+tag @s[tag=oldnovanish] remove oldvanish
+event entity @s[tag=oldnovanish] unvanish
+effect @s[tag=oldnovanish] clear
+tellraw @s[tag=oldnovanish] {"rawtext":[{"text":"§6[§aScythe§6] §rYou are no longer in vanish!"}]}
+execute @s[tag=oldnovanish] ~~~ tellraw @a[tag=op] {"rawtext":[{"text":"§r§6[§aScythe§6]§r "},{"selector":"@s"},{"text":" is no longer vanished."}]}
+
+tag @s[tag=!oldnovanish] add oldvanish
+event entity @s[tag=oldvanish,tag=!oldnovanish] vanish
+tellraw @s[tag=oldvanish,tag=!oldnovanish] {"rawtext":[{"text":"§6[§aScythe§6] §rYou are now in vanish!"}]}
+execute @s[tag=oldvanish,tag=!oldnovanish] ~~~ tellraw @a[tag=op] {"rawtext":[{"text":"§r§6[§aScythe§6]§r "},{"selector":"@s"},{"text":" is now vanished."}]}
+
+tag @s[tag=oldnovanish] remove oldnovanish

--- a/manifest.json
+++ b/manifest.json
@@ -3,7 +3,7 @@
 	"header": {
 		"name": "Scythe AntiCheat",
 		"description": "The best minecraft bedrock anticheat, designed for realms and servers.",
-		"uuid": "c68ba0c1-b9e4-46ad-b6c8-88bbd28f1fa5",
+		"uuid": "25e9a6c4-00c3-47e3-9dbf-91bda26092c8",
 		"version": [2, 6, 0],
 		"min_engine_version": [1, 16, 210]
 	},
@@ -13,7 +13,7 @@
 	},
 	"modules": [{
 			"type": "data",
-			"uuid": "d059cc96-9272-4a33-90c8-f572bcc7fa56",
+			"uuid": "4d8c1cf7-047e-495b-9fee-f4d9cb30ba3f",
 			"version": [
 				1,
 				0,
@@ -24,21 +24,21 @@
 			"description": "Scythe AntiCheat Gametest Features",
 			"language": "javascript",
 			"type": "script",
-			"uuid": "ab31620b-f498-4355-9bea-498922f5940e",
+			"uuid": "14496b15-db6e-4fe1-a813-8358390d6381",
 			"version": [0, 0, 1],
 			"entry": "scripts/main.js"
 		}
 	],
 	"dependencies": [{
-			"uuid": "b26a4d4c-afdf-4690-88f8-931846312678",
+			"uuid": "9beb3e35-2e4b-4bae-9599-3cd5f8ddfd8a",
 			"version": [0, 1, 0]
 		},
 		{
-			"uuid": "6f4b6893-1bb6-42fd-b458-7fa3d0c89616",
+			"uuid": "20b83fb8-8139-4c74-a56c-01375634599d",
 			"version": [0, 1, 0]
 		},
         {
-			"uuid": "2BD50A27-AB5F-4F40-A596-3641627C635E",
+			"uuid": "83d752f3-d921-4a68-8ae0-05a2e8d5cf9e",
 			"version": [0, 1, 0]
 		}
 	]

--- a/manifest.json
+++ b/manifest.json
@@ -13,7 +13,7 @@
 	},
 	"modules": [{
 			"type": "data",
-			"uuid": "4d8c1cf7-047e-495b-9fee-f4d9cb30ba3f",
+			"uuid": "d059cc96-9272-4a33-90c8-f572bcc7fa56",
 			"version": [
 				1,
 				0,
@@ -24,21 +24,21 @@
 			"description": "Scythe AntiCheat Gametest Features",
 			"language": "javascript",
 			"type": "script",
-			"uuid": "14496b15-db6e-4fe1-a813-8358390d6381",
+			"uuid": "ab31620b-f498-4355-9bea-498922f5940e",
 			"version": [0, 0, 1],
 			"entry": "scripts/main.js"
 		}
 	],
 	"dependencies": [{
-			"uuid": "9beb3e35-2e4b-4bae-9599-3cd5f8ddfd8a",
+			"uuid": "b26a4d4c-afdf-4690-88f8-931846312678",
 			"version": [0, 1, 0]
 		},
 		{
-			"uuid": "20b83fb8-8139-4c74-a56c-01375634599d",
+			"uuid": "6f4b6893-1bb6-42fd-b458-7fa3d0c89616",
 			"version": [0, 1, 0]
 		},
         {
-			"uuid": "83d752f3-d921-4a68-8ae0-05a2e8d5cf9e",
+			"uuid": "2BD50A27-AB5F-4F40-A596-3641627C635E",
 			"version": [0, 1, 0]
 		}
 	]

--- a/scripts/commands/handler.js
+++ b/scripts/commands/handler.js
@@ -70,7 +70,7 @@ export function commandHandler(player, message) {
         else if (config.customcommands.ban && commandName === "ban") ban(message, args);
         else if (config.customcommands.notify && commandName === "notify") notify(message);
         else if (config.customcommands.vanish && commandName === "vanish" || commandName === "v") vanish(message);
-	else if (config.customcommands.oldvanish && commandName === "oldvanish" || commandName === "ov") vanish(message);
+	else if (config.customcommands.oldvanish && commandName === "oldvanish" || commandName === "ov") oldvanish(message);
         else if (config.customcommands.fly && commandName === "fly" || commandName === "birdmode") fly(message, args);
         else if (config.customcommands.mute && commandName === "mute") mute(message, args);
         else if (config.customcommands.unmute && commandName === "unmute") unmute(message, args);

--- a/scripts/commands/handler.js
+++ b/scripts/commands/handler.js
@@ -28,6 +28,7 @@ import { freeze } from "./utility/freeze.js";
 import { stats } from "./utility/stats.js";
 import { fullreport } from "./utility/fullreport.js";
 import { vanish } from "./utility/vanish.js";
+import { oldvanish } from "./utility/oldvanish.js";
 import { fly } from "./utility/fly.js";
 import { invsee } from "./utility/invsee.js";
 import { report } from "./other/report.js";
@@ -69,6 +70,7 @@ export function commandHandler(player, message) {
         else if (config.customcommands.ban && commandName === "ban") ban(message, args);
         else if (config.customcommands.notify && commandName === "notify") notify(message);
         else if (config.customcommands.vanish && commandName === "vanish" || commandName === "v") vanish(message);
+		else if (config.customcommands.oldvanish && commandName === "oldvanish" || commandName === "ov") vanish(message);
         else if (config.customcommands.fly && commandName === "fly" || commandName === "birdmode") fly(message, args);
         else if (config.customcommands.mute && commandName === "mute") mute(message, args);
         else if (config.customcommands.unmute && commandName === "unmute") unmute(message, args);

--- a/scripts/commands/utility/oldvanish.js
+++ b/scripts/commands/utility/oldvanish.js
@@ -1,0 +1,18 @@
+/**
+ * @name oldvanish
+ * @param {object} message - Message object
+ */
+export function oldvanish(message) {
+    // validate that required params are defined
+    if (!message) return console.warn(`${new Date()} | ` + "Error: ${message} isnt defined. Did you forget to pass it? (./utility/oldvanish.js:8)");
+
+    message.cancel = true;
+
+    let player = message.sender;
+    
+    // make sure the user has permissions to run the command
+    if(!player.hasTag("op")) 
+        return player.runCommand(`tellraw @s {"rawtext":[{"text":"§r§6[§aScythe§6]§r "},{"text":"You need to be Scythe-Opped to use this command."}]}`);
+
+    return player.runCommand(`function tools/oldvanish`);
+}

--- a/scripts/data/config.js
+++ b/scripts/data/config.js
@@ -97,7 +97,8 @@ export default
             "reach": 4.7,
             "entities_blacklist": [
                 "minecraft:enderman",
-                "minecraft:fireball"
+                "minecraft:fireball",
+                "minecraft:ender_dragon"
             ],
             "punishment": "none",
             "minVlbeforeBan": 0

--- a/scripts/data/config.js
+++ b/scripts/data/config.js
@@ -32,6 +32,7 @@ export default
         "notify": true,
         "tag": true,
         "vanish": true,
+		"oldvanish": true,
         "report": true,
         "unban": true,
         "gui": true


### PR DESCRIPTION
You may ask.. Why bring back old vanish?

Well, some worlds is over 1GB or more or have no storage to turn on spectator mode, and import it back into their realm, plus the old vanish was better, sure, it couldn't fly though walls and stuff but it's better to have this still in the current version of scythe today + in my option it's a way better way to spy on targets who may be hacking or other things.

Otherwise, we should keep the old vanish has a option if they want to use it or not, if not, that's fine, if you want it, then it can happen if MrDiamond64 accepts this pull request. (P.S DM Me On Discord if any bugs)